### PR TITLE
PC-NONE: Bump upload-artifacts to v4

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ always() }}
 
       - name: Upload dotnet test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: TestResults


### PR DESCRIPTION
# Description

see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/