### PR TITLE
PC-1808: Rename staging appSettings file and update URL

### DIFF
--- a/WhlgPortalWebsite/appsettings.Staging.json
+++ b/WhlgPortalWebsite/appsettings.Staging.json
@@ -1,0 +1,5 @@
+{
+    "Global": {
+        "AppBaseUrl": "https://staging.apply-warm-homes-local-grant.service.gov.uk/portal"
+    }
+}

--- a/WhlgPortalWebsite/appsettings.UAT.json
+++ b/WhlgPortalWebsite/appsettings.UAT.json
@@ -1,5 +1,0 @@
-{
-    "Global": {
-        "AppBaseUrl": "https://uat.apply-warm-homes-local-grant.service.gov.uk/portal"
-    }
-}


### PR DESCRIPTION
[PC-1808](https://beisdigital.atlassian.net/browse/PC-1808)

# Description

`ASPNETCORE_ENVIRONMENT` is `Staging` on the staging environment, so this wasn't being picked up. Looks like it was always that way for HUG2 as well.

Note this is based on `staging`, not `develop`: I'll merge `staging` back to `develop` afterwards.

# Checklist

- [ ] I have made any necessary updates to the documentation
- [ ] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL26SYw4=/)
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [ ] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the main HUG2 repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta)

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 