### PR TITLE
PC-1243: Add comment to make formatter ignore Date accessor

### DIFF
--- a/WhlgPortalWebsite.BusinessLogic/Services/FileService/StreamService.cs
+++ b/WhlgPortalWebsite.BusinessLogic/Services/FileService/StreamService.cs
@@ -12,14 +12,12 @@ namespace WhlgPortalWebsite.BusinessLogic.Services.FileService;
 
 public class StreamService : IStreamService
 {
-    /// <summary>
-    ///     Beware that some "set" accessors in this class have been removed by the linter, when they are necessary for the
-    ///     class to function
-    ///     Check the readme for more information about code auto-formatting.
-    /// </summary>
     private class CsvReferralRequest
     {
+        // Below comment stops resharper from trimming the "set" accessor from Date, which is required but only used dynamically
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
         [Name("Referral date")] public string Date { get; set; }
+
         [Optional] [Name("Referral code")] public string Code { get; set; }
         [Optional] public string Name { get; set; }
         [Optional] public string Email { get; set; }


### PR DESCRIPTION
Following @jdgage 's comment on [PC-1243's QA PR](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal/pull/51#pullrequestreview-2784766406)

This comment should have resharper disable the specific formatting rule for the specific line where it's a problem, with a small note describing why it's necessary, since we don't use this often.