### PR TITLE
PC-NONE: Fix ability to search delivery partners

### DIFF
--- a/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
+++ b/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
@@ -7,12 +7,12 @@ namespace WhlgPortalWebsite.Models;
 
 public class ServiceManagerHomepageViewModel
 {
-    public string UserSearch { get; }
+    public string SearchEmailAddress { get; }
     public IEnumerable<AuthorityUserListing> UserList { get; }
 
     public ServiceManagerHomepageViewModel(IEnumerable<User> users)
     {
-        UserSearch = "";
+        SearchEmailAddress = "";
         UserList = users
             .OrderBy(user => user.EmailAddress)
             .Select(user => new AuthorityUserListing(user));

--- a/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
+++ b/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
@@ -19,7 +19,7 @@
 <h3 class="govuk-heading-m">View existing users</h3>
 <form method="get">
     @(await Html.GovUkTextInputFor(
-        m => m.UserSearch,
+        m => m.SearchEmailAddress,
         labelOptions: new LabelViewModel
         {
             Text = "Search for a user"


### PR DESCRIPTION
# Description

didn't work as during development the userSearch param was renamed to searchEmailAddress on the controller method, but not the underlying view model

this has now been resolved

# Screenshots

![image](https://github.com/user-attachments/assets/83a400b7-3fa1-46e9-bc7c-f6d76374b428)