### PR TITLE
PC-1912: Allow for manual running of reminder emails

### DIFF
--- a/WhlgPortalWebsite.BusinessLogic/Services/RegularJobsService.cs
+++ b/WhlgPortalWebsite.BusinessLogic/Services/RegularJobsService.cs
@@ -1,7 +1,7 @@
 ﻿namespace WhlgPortalWebsite.BusinessLogic.Services;
 
 public class RegularJobsService(
-    ReminderEmailsService reminderEmailsService)
+    IReminderEmailsService reminderEmailsService)
 {
     public async Task SendReminderEmailsAsync()
     {

--- a/WhlgPortalWebsite.BusinessLogic/Services/RegularJobsService.cs
+++ b/WhlgPortalWebsite.BusinessLogic/Services/RegularJobsService.cs
@@ -1,57 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
-using WhlgPortalWebsite.BusinessLogic.ExternalServices.EmailSending;
-using WhlgPortalWebsite.BusinessLogic.Services.FileService;
-
-namespace WhlgPortalWebsite.BusinessLogic.Services;
+﻿namespace WhlgPortalWebsite.BusinessLogic.Services;
 
 public class RegularJobsService(
-    IUserService userService,
-    IEmailSender emailSender,
-    IFileRetrievalService fileRetrievalService,
-    ILogger<RegularJobsService> logger)
+    ReminderEmailsService reminderEmailsService)
 {
-    private readonly ILogger logger = logger;
-
     public async Task SendReminderEmailsAsync()
     {
-        logger.LogInformation("Sending reminder emails");
-
-        var activeUsers = await userService.GetAllActiveDeliveryPartnersAsync();
-        foreach (var user in activeUsers)
-        {
-            IEnumerable<FileData> userCsvFiles;
-
-            try
-            {
-                userCsvFiles = await fileRetrievalService.GetFileDataForUserAsync(user.EmailAddress);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error encountered while attempting to read files from S3");
-                throw;
-            }
-
-            var hasUpdates = userCsvFiles.Any(cf => cf.HasUpdatedSinceLastDownload);
-
-            if (!hasUpdates) continue;
-
-            try
-            {
-                emailSender.SendNewReferralReminderEmail(user.EmailAddress);
-            }
-            catch (EmailSenderException ex)
-            {
-                // We log a warning here and do not re-throw, as we don't want this error
-                //   to prevent the emails being sent to the other users.
-                // If an email fails to be sent, this will have to be caught by
-                //   checking the logs.
-                logger.LogWarning
-                (
-                    ex,
-                    "Error encountered while attempting to send reminder email to {EmailAddress}",
-                    user.EmailAddress
-                );
-            }
-        }
+        await reminderEmailsService.SendReminderEmailsAsync();
     }
 }

--- a/WhlgPortalWebsite.BusinessLogic/Services/ReminderEmailsService.cs
+++ b/WhlgPortalWebsite.BusinessLogic/Services/ReminderEmailsService.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+using WhlgPortalWebsite.BusinessLogic.ExternalServices.EmailSending;
+using WhlgPortalWebsite.BusinessLogic.Services.FileService;
+
+namespace WhlgPortalWebsite.BusinessLogic.Services;
+
+public class ReminderEmailsService(
+    IUserService userService,
+    IEmailSender emailSender,
+    IFileRetrievalService fileRetrievalService,
+    ILogger<RegularJobsService> logger)
+{
+    private readonly ILogger logger = logger;
+
+    public async Task SendReminderEmailsAsync()
+    {
+        logger.LogInformation("Sending reminder emails");
+
+        var activeUsers = await userService.GetAllActiveDeliveryPartnersAsync();
+        foreach (var user in activeUsers)
+        {
+            IEnumerable<FileData> userCsvFiles;
+
+            try
+            {
+                userCsvFiles = await fileRetrievalService.GetFileDataForUserAsync(user.EmailAddress);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error encountered while attempting to read files from S3");
+                throw;
+            }
+
+            var hasUpdates = userCsvFiles.Any(cf => cf.HasUpdatedSinceLastDownload);
+
+            if (!hasUpdates) continue;
+
+            try
+            {
+                emailSender.SendNewReferralReminderEmail(user.EmailAddress);
+            }
+            catch (EmailSenderException ex)
+            {
+                // We log a warning here and do not re-throw, as we don't want this error
+                //   to prevent the emails being sent to the other users.
+                // If an email fails to be sent, this will have to be caught by
+                //   checking the logs.
+                logger.LogWarning
+                (
+                    ex,
+                    "Error encountered while attempting to send reminder email to {EmailAddress}",
+                    user.EmailAddress
+                );
+            }
+        }
+    }
+}

--- a/WhlgPortalWebsite.BusinessLogic/Services/ReminderEmailsService.cs
+++ b/WhlgPortalWebsite.BusinessLogic/Services/ReminderEmailsService.cs
@@ -4,11 +4,16 @@ using WhlgPortalWebsite.BusinessLogic.Services.FileService;
 
 namespace WhlgPortalWebsite.BusinessLogic.Services;
 
+public interface IReminderEmailsService
+{
+    Task SendReminderEmailsAsync();
+}
+
 public class ReminderEmailsService(
     IUserService userService,
     IEmailSender emailSender,
     IFileRetrievalService fileRetrievalService,
-    ILogger<RegularJobsService> logger)
+    ILogger<RegularJobsService> logger) : IReminderEmailsService
 {
     private readonly ILogger logger = logger;
 

--- a/WhlgPortalWebsite.UnitTests/BusinessLogic/Services/ReminderEmailsServiceTests.cs
+++ b/WhlgPortalWebsite.UnitTests/BusinessLogic/Services/ReminderEmailsServiceTests.cs
@@ -14,13 +14,13 @@ using WhlgPortalWebsite.BusinessLogic.Services.FileService;
 namespace Tests.BusinessLogic.Services;
 
 [TestFixture]
-public class RegularJobsServiceTests
+public class ReminderEmailsServiceTests
 {
     private Mock<ILogger<RegularJobsService>> mockLogger;
     private Mock<IDataAccessProvider> mockDataAccessProvider;
     private Mock<IEmailSender> mockEmailSender;
     private Mock<IFileRetrievalService> mockFileRetrievalService;
-    private RegularJobsService underTest;
+    private ReminderEmailsService underTest;
 
     private const string EmailAddress = "test@example.com";
 
@@ -33,7 +33,7 @@ public class RegularJobsServiceTests
         mockFileRetrievalService = new Mock<IFileRetrievalService>();
         var userService = new UserService(mockDataAccessProvider.Object);
 
-        underTest = new RegularJobsService(userService, mockEmailSender.Object,
+        underTest = new ReminderEmailsService(userService, mockEmailSender.Object,
             mockFileRetrievalService.Object, mockLogger.Object);
     }
 

--- a/WhlgPortalWebsite.UnitTests/Website/Controllers/ServiceManagerControllerTests.cs
+++ b/WhlgPortalWebsite.UnitTests/Website/Controllers/ServiceManagerControllerTests.cs
@@ -17,6 +17,7 @@ public class ServiceManagerControllerTests
 {
     private Mock<IUserService> mockUserService;
     private Mock<IAuthorityService> mockAuthorityService;
+    private Mock<IReminderEmailsService> mockReminderEmailsService;
     private ServiceManagerController serviceManagerController;
 
     [SetUp]
@@ -24,7 +25,9 @@ public class ServiceManagerControllerTests
     {
         mockUserService = new Mock<IUserService>();
         mockAuthorityService = new Mock<IAuthorityService>();
-        serviceManagerController = new ServiceManagerController(mockUserService.Object, mockAuthorityService.Object);
+        mockReminderEmailsService = new Mock<IReminderEmailsService>();
+        serviceManagerController = new ServiceManagerController(mockUserService.Object, mockAuthorityService.Object,
+            mockReminderEmailsService.Object);
     }
 
     [Test]
@@ -212,5 +215,16 @@ public class ServiceManagerControllerTests
 
         mockAuthorityService.Verify(x => x.GetConsortiumByConsortiumCodeAsync(consortiumCode), Times.Once);
         mockAuthorityService.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task SendReminderEmailsGet_CallsReminderEmailsJob()
+    {
+        // Act
+        await serviceManagerController.SendReminderEmails_Get();
+
+        // Assert
+        mockReminderEmailsService.Verify(x => x.SendReminderEmailsAsync(), Times.Once);
+        mockReminderEmailsService.VerifyNoOtherCalls();
     }
 }

--- a/WhlgPortalWebsite.UnitTests/Website/Controllers/ServiceManagerControllerTests.cs
+++ b/WhlgPortalWebsite.UnitTests/Website/Controllers/ServiceManagerControllerTests.cs
@@ -218,10 +218,10 @@ public class ServiceManagerControllerTests
     }
 
     [Test]
-    public async Task SendReminderEmailsGet_CallsReminderEmailsJob()
+    public async Task SendReminderEmailsPost_CallsReminderEmailsJob()
     {
         // Act
-        await serviceManagerController.SendReminderEmails_Get();
+        await serviceManagerController.SendReminderEmails_Post();
 
         // Assert
         mockReminderEmailsService.Verify(x => x.SendReminderEmailsAsync(), Times.Once);

--- a/WhlgPortalWebsite/Controllers/HomeController.cs
+++ b/WhlgPortalWebsite/Controllers/HomeController.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Hosting;
 using WhlgPortalWebsite.BusinessLogic.Models;
 using WhlgPortalWebsite.BusinessLogic.Models.Enums;
 using WhlgPortalWebsite.BusinessLogic.Services;
@@ -15,7 +17,8 @@ namespace WhlgPortalWebsite.Controllers;
 
 public class HomeController(
     IUserService userService,
-    IFileRetrievalService fileRetrievalService)
+    IFileRetrievalService fileRetrievalService,
+    IWebHostEnvironment webHostEnvironment)
     : Controller
 {
     private const int PageSize = 20;
@@ -94,7 +97,10 @@ public class HomeController(
     {
         var users = await userService.SearchAllDeliveryPartnersAsync(searchEmailAddress);
 
-        var homepageViewModel = new ServiceManagerHomepageViewModel(users);
+        var homepageViewModel = new ServiceManagerHomepageViewModel(users)
+        {
+            ShouldShowManualJobRunner = !webHostEnvironment.IsProduction()
+        };
 
         return View("ServiceManager/Index", homepageViewModel);
     }

--- a/WhlgPortalWebsite/Controllers/HomeController.cs
+++ b/WhlgPortalWebsite/Controllers/HomeController.cs
@@ -25,6 +25,7 @@ public class HomeController(
 
     [HttpGet("/")]
     public async Task<IActionResult> Index([FromQuery] List<string> codes, [FromQuery] string searchEmailAddress,
+        [FromQuery] bool jobSuccess,
         int page = 1)
     {
         var userEmailAddress = HttpContext.User.GetEmailAddress();
@@ -33,7 +34,7 @@ public class HomeController(
         return userData.Role switch
         {
             UserRole.DeliveryPartner => await RenderDeliveryPartnerHomepage(codes, page, userEmailAddress, userData),
-            UserRole.ServiceManager => await RenderServiceManagerHomepage(searchEmailAddress),
+            UserRole.ServiceManager => await RenderServiceManagerHomepage(searchEmailAddress, jobSuccess),
             _ => throw new ArgumentOutOfRangeException()
         };
     }
@@ -93,13 +94,14 @@ public class HomeController(
         return View("DeliveryPartner/ReferralFiles", homepageViewModel);
     }
 
-    private async Task<IActionResult> RenderServiceManagerHomepage(string searchEmailAddress)
+    private async Task<IActionResult> RenderServiceManagerHomepage(string searchEmailAddress, bool jobSuccess)
     {
         var users = await userService.SearchAllDeliveryPartnersAsync(searchEmailAddress);
 
         var homepageViewModel = new ServiceManagerHomepageViewModel(users)
         {
-            ShouldShowManualJobRunner = !webHostEnvironment.IsProduction()
+            ShowManualJobRunner = !webHostEnvironment.IsProduction(),
+            ShowJobSuccess = jobSuccess
         };
 
         return View("ServiceManager/Index", homepageViewModel);

--- a/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
+++ b/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
@@ -128,4 +128,10 @@ public class ServiceManagerController(IUserService userService, IAuthorityServic
 
         return RedirectToAction("Index", "Home");
     }
+
+    [HttpGet("send-reminder-emails")]
+    public IActionResult SendReminderEmails_Get()
+    {
+        return RedirectToAction(nameof(HomeController.Index), "Home");
+    }
 }

--- a/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
+++ b/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
@@ -15,7 +15,7 @@ namespace WhlgPortalWebsite.Controllers;
 public class ServiceManagerController(
     IUserService userService,
     IAuthorityService authorityService,
-    ReminderEmailsService reminderEmailsService) : Controller
+    IReminderEmailsService reminderEmailsService) : Controller
 {
     [HttpGet("onboard-delivery-partner")]
     public IActionResult OnboardDeliveryPartner_Get()

--- a/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
+++ b/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
@@ -132,8 +132,8 @@ public class ServiceManagerController(
         return RedirectToAction("Index", "Home");
     }
 
-    [HttpGet("send-reminder-emails")]
-    public async Task<IActionResult> SendReminderEmails_Get()
+    [HttpPost("send-reminder-emails")]
+    public async Task<IActionResult> SendReminderEmails_Post()
     {
         await reminderEmailsService.SendReminderEmailsAsync();
 

--- a/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
+++ b/WhlgPortalWebsite/Controllers/ServiceManagerController.cs
@@ -12,7 +12,10 @@ namespace WhlgPortalWebsite.Controllers;
 
 [TypeFilter(typeof(RequiresServiceManagerFilter))]
 [Route("service-manager")]
-public class ServiceManagerController(IUserService userService, IAuthorityService authorityService) : Controller
+public class ServiceManagerController(
+    IUserService userService,
+    IAuthorityService authorityService,
+    ReminderEmailsService reminderEmailsService) : Controller
 {
     [HttpGet("onboard-delivery-partner")]
     public IActionResult OnboardDeliveryPartner_Get()
@@ -130,8 +133,10 @@ public class ServiceManagerController(IUserService userService, IAuthorityServic
     }
 
     [HttpGet("send-reminder-emails")]
-    public IActionResult SendReminderEmails_Get()
+    public async Task<IActionResult> SendReminderEmails_Get()
     {
-        return RedirectToAction(nameof(HomeController.Index), "Home");
+        await reminderEmailsService.SendReminderEmailsAsync();
+
+        return RedirectToAction(nameof(HomeController.Index), "Home", new { jobSuccess = true });
     }
 }

--- a/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
+++ b/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
@@ -8,7 +8,8 @@ public class ServiceManagerHomepageViewModel
 {
     public string SearchEmailAddress { get; }
     public IEnumerable<AuthorityUserListing> UserList { get; }
-    public bool ShouldShowManualJobRunner { get; set; }
+    public bool ShowJobSuccess { get; set; }
+    public bool ShowManualJobRunner { get; set; }
 
     public ServiceManagerHomepageViewModel(IEnumerable<User> users)
     {

--- a/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
+++ b/WhlgPortalWebsite/Models/ServiceManagerHomepageViewModel.cs
@@ -8,6 +8,7 @@ public class ServiceManagerHomepageViewModel
 {
     public string SearchEmailAddress { get; }
     public IEnumerable<AuthorityUserListing> UserList { get; }
+    public bool ShouldShowManualJobRunner { get; set; }
 
     public ServiceManagerHomepageViewModel(IEnumerable<User> users)
     {

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -46,7 +46,7 @@ namespace WhlgPortalWebsite
             services.AddScoped<IDataAccessProvider, DataAccessProvider>();
             services.AddScoped<IFileRetrievalService, FileRetrievalService>();
             services.AddScoped<IStreamService, StreamService>();
-            services.AddScoped<ReminderEmailsService>();
+            services.AddScoped<IReminderEmailsService, ReminderEmailsService>();
             services.AddSingleton<StaticAssetsVersioningService>();
             // This allows encrypted cookies to be understood across multiple web server instances
             services.AddDataProtection().PersistKeysToDbContext<WhlgDbContext>();

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -55,6 +55,7 @@ namespace WhlgPortalWebsite
             services.AddScoped<IDataAccessProvider, DataAccessProvider>();
             services.AddScoped<IFileRetrievalService, FileRetrievalService>();
             services.AddScoped<IStreamService, StreamService>();
+            services.AddScoped<ReminderEmailsService>();
             services.AddSingleton<StaticAssetsVersioningService>();
             // This allows encrypted cookies to be understood across multiple web server instances
             services.AddDataProtection().PersistKeysToDbContext<WhlgDbContext>();

--- a/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
+++ b/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
@@ -88,7 +88,10 @@
     <h3 class="govuk-heading-m">Send unread referrals reminder email</h3>
     <p class="govuk-body">This will send emails to all onboarded Delivery Partners who have unread referrals in the portal reminding them to review them.</p>
     <p class="govuk-body">This typically runs at 07:00am GMT daily.</p>
-    <a href="@Url.Action(nameof(ServiceManagerController.SendReminderEmails_Get), "ServiceManager")" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-        Run Job Now
-    </a>
+    <form method="post" action="@Url.Action(nameof(ServiceManagerController.SendReminderEmails_Post), "ServiceManager")">
+        @Html.AntiForgeryToken()
+        <button type="submit" class="govuk-button" data-module="govuk-button" draggable="false" role="button">
+            Run Job Now
+        </button>
+    </form>
 }

--- a/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
+++ b/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
+@using WhlgPortalWebsite.Controllers
 @model WhlgPortalWebsite.Models.ServiceManagerHomepageViewModel
 
 @{
@@ -68,3 +69,18 @@
         }
     }).ToList()
 })
+
+@if (Model.ShouldShowManualJobRunner)
+{
+    <h2 class="govuk-heading-l">Run regular jobs manually</h2>
+    @await Html.GovUkWarningText(new WarningTextViewModel
+    {
+        Text = "Regular jobs can only be run manually on pre-production environments."
+    })
+    <h3 class="govuk-heading-m">Send unread referrals reminder email</h3>
+    <p class="govuk-body">This will send emails to all onboarded Delivery Partners who have unread referrals in the portal reminding them to review them.</p>
+    <p class="govuk-body">This typically runs at 07:00am GMT daily.</p>
+    <a href="@Url.Action(nameof(ServiceManagerController.SendReminderEmails_Get), "ServiceManager")" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Run Job Now
+    </a>
+}

--- a/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
+++ b/WhlgPortalWebsite/Views/Home/ServiceManager/Index.cshtml
@@ -9,6 +9,14 @@
 
 <h1 class="govuk-heading-xl">Warm Homes: Local Grant Service Manager Portal</h1>
 
+@if (Model.ShowJobSuccess)
+{
+    @await Html.GovUkNotificationBanner(new NotificationBannerViewModel
+    {
+        Text = "Job run successfully"
+    })
+}
+
 <h2 class="govuk-heading-l">Manage Local Authority/Consortia Users</h2>
 <h3 class="govuk-heading-m">Add a new user</h3>
 @(await Html.GovUkButton(new ButtonViewModel
@@ -70,7 +78,7 @@
     }).ToList()
 })
 
-@if (Model.ShouldShowManualJobRunner)
+@if (Model.ShowManualJobRunner)
 {
     <h2 class="govuk-heading-l">Run regular jobs manually</h2>
     @await Html.GovUkWarningText(new WarningTextViewModel

--- a/WhlgPortalWebsite/Views/ServiceManager/Test.cshtml
+++ b/WhlgPortalWebsite/Views/ServiceManager/Test.cshtml
@@ -1,6 +1,0 @@
-﻿@{
-    ViewBag.Title = $"Warm Homes: Local Grant Portal";
-}
-
-@* TODO: PC-1841/PC-1842 replace this page with service manager specific views *@
-<p class="govuk-body">This page can only be viewed by Service Managers</p>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1912)

# Description

adds new function to the Service Manager portal to allow for running the reminder email service to send unread referral reminder emails to delivery partners

includes explanatory text and a success notification

splits the email sending service out of the regular jobs service so the web controllers dont need to be tied to the regular jobs service

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL26SYw4=/)

# Screenshots

![image](https://github.com/user-attachments/assets/5151572e-5d29-4c76-a0bd-d46a4c8cb181)