### PR TITLE
DESNZ-2224: Catch all remote errors with cognito auth

### DIFF
--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.S3;
@@ -19,6 +18,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using WhlgPortalWebsite.BusinessLogic;
 using WhlgPortalWebsite.BusinessLogic.ExternalServices.EmailSending;
@@ -109,13 +109,40 @@ namespace WhlgPortalWebsite
                     // - Navigating directly to /signin-oidc without a code query parameter
                     // - Some other unknown cause, e.g. the browser handling SameSite cookie settings incorrectly
                     //
-                    // For any remote failure we redirect to the homepage where the user will be re-authenticated
-                    // with a fresh correlation cookie. This introduces a small risk of an infinite redirect loop
-                    // upon misconfiguration, but we expect this to be rare.
+                    // For the first failure we redirect to the homepage where the user will be re-authenticated
+                    // with a fresh correlation cookie. A short-lived retry cookie tracks that we have already
+                    // redirected once: if the failure recurs before that cookie expires we stop suppressing it
+                    // so that genuine configuration or IdP outages surface as errors rather than silent loops.
+                    const string oidcRetryCookie = "oidc-retry";
+
                     options.Events.OnRemoteFailure = context =>
                     {
-                        context.Response.Redirect(Constants.BASE_PATH);
-                        context.HandleResponse();
+                        var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Startup>>();
+
+                        if (context.Request.Cookies.ContainsKey(oidcRetryCookie))
+                        {
+                            logger.LogError(context.Failure, "OIDC remote authentication failure on retry");
+                        }
+                        else
+                        {
+                            logger.LogWarning(context.Failure, "OIDC remote authentication failure");
+                            context.Response.Cookies.Append(oidcRetryCookie, "1", new CookieOptions
+                            {
+                                HttpOnly = true,
+                                // This will make the cookie environment agnostic
+                                Secure = context.Request.IsHttps,
+                                MaxAge = TimeSpan.FromMinutes(15),
+                                SameSite = SameSiteMode.Lax,
+                            });
+                            context.Response.Redirect(Constants.BASE_PATH);
+                            context.HandleResponse();
+                        }
+                        return Task.CompletedTask;
+                    };
+
+                    options.Events.OnTokenValidated = context =>
+                    {
+                        context.Response.Cookies.Delete(oidcRetryCookie);
                         return Task.CompletedTask;
                     };
                 });

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -108,11 +108,7 @@ namespace WhlgPortalWebsite
                     // - The user cancelling login at the Cognito page (Cognito returns an error, no code)
                     // - Navigating directly to /signin-oidc without a code query parameter
                     // - Some other unknown cause, e.g. the browser handling SameSite cookie settings incorrectly
-                    //
-                    // For the first failure we redirect to the homepage where the user will be re-authenticated
-                    // with a fresh correlation cookie. A short-lived retry cookie tracks that we have already
-                    // redirected once: if the failure recurs before that cookie expires we stop suppressing it
-                    // so that genuine configuration or IdP outages surface as errors rather than silent loops.
+
                     const string oidcRetryCookie = "oidc-retry";
 
                     options.Events.OnRemoteFailure = context =>

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -133,6 +133,7 @@ namespace WhlgPortalWebsite
                             context.Response.Redirect(Constants.BASE_PATH);
                             context.HandleResponse();
                         }
+
                         return Task.CompletedTask;
                     };
 

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -101,23 +101,21 @@ namespace WhlgPortalWebsite
                     options.CorrelationCookie.HttpOnly = true;
                     options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 
-                    // We see relatively frequent errors where the user doesn't have a valid correlation cookie.
-                    // This may be for a number of reasons:
-                    // - The cookie expires after 15 minutes
+                    // We see relatively frequent errors where the OIDC remote auth flow fails. This may be for
+                    // a number of reasons:
+                    // - The correlation/nonce cookie expires after 15 minutes
                     // - Landing on the login screen without first hitting the app (therefore missing the cookie)
+                    // - The user cancelling login at the Cognito page (Cognito returns an error, no code)
+                    // - Navigating directly to /signin-oidc without a code query parameter
                     // - Some other unknown cause, e.g. the browser handling SameSite cookie settings incorrectly
                     //
-                    // If we detect a correlation error, we redirect to the homepage where the user will be
-                    // re-authenticated with a fresh correlation cookie. This introduces a small risk of an
-                    // infinite redirect loop upon misconfiguration, but we expect this to be rare.
+                    // For any remote failure we redirect to the homepage where the user will be re-authenticated
+                    // with a fresh correlation cookie. This introduces a small risk of an infinite redirect loop
+                    // upon misconfiguration, but we expect this to be rare.
                     options.Events.OnRemoteFailure = context =>
                     {
-                        if (context.Failure?.Message.Contains("Correlation failed") is true)
-                        {
-                            context.Response.Redirect(Constants.BASE_PATH);
-                            context.HandleResponse();
-                        }
-
+                        context.Response.Redirect(Constants.BASE_PATH);
+                        context.HandleResponse();
                         return Task.CompletedTask;
                     };
                 });

--- a/WhlgPortalWebsite/Startup.cs
+++ b/WhlgPortalWebsite/Startup.cs
@@ -125,6 +125,7 @@ namespace WhlgPortalWebsite
                             context.Response.Cookies.Append(oidcRetryCookie, "1", new CookieOptions
                             {
                                 HttpOnly = true,
+                                Path = Constants.BASE_PATH,
                                 // This will make the cookie environment agnostic
                                 Secure = context.Request.IsHttps,
                                 MaxAge = TimeSpan.FromMinutes(15),


### PR DESCRIPTION
[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-2224)

# Description

- Catch all remote OIDC failures and redirect the user to cognito sign in page
  - This used to only catch correlation failures
- Implement retry logic for OIDC remote failures
  - Log an error only if the retry fails

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it

# Screenshots

## After navigating to `/portal/signin-oidc`, user is shown the Cognito sign in page below
<img width="1755" height="835" alt="image" src="https://github.com/user-attachments/assets/dce30e65-b400-4c65-8e3e-449546cafcb2" />
